### PR TITLE
Release 17

### DIFF
--- a/Model/lib/wdk/microbiomeModel.xml
+++ b/Model/lib/wdk/microbiomeModel.xml
@@ -9,7 +9,7 @@
 <wdkModel>
 
   <constant name="releaseDate">1 January 1900 00:00</constant>
-  <constant name="buildNumber">16</constant>
+  <constant name="buildNumber">17</constant>
 
   <constant name="attributesReporterDisplayName">Tab- or comma-delimited (openable in Excel) - choose columns to make a custom table</constant>
   <constant name="tableReporterDisplayName">Tab- or comma-delimited (openable in Excel) - choose a pre-configured table</constant>

--- a/Model/lib/wdk/model/questions/params/microbiomeSampleParams.xml
+++ b/Model/lib/wdk/model/questions/params/microbiomeSampleParams.xml
@@ -326,7 +326,7 @@ select distinct ontology_term_source_id as ontology_term_name, parent_ontology_t
                          taxon_level * 2 - 1 as ordering
                   from apidbTuning.TaxonAbundance
                 union
-                  select term_id as ontology_term_name,
+                  select category || ':' || term as ontology_term_name,
                          category as parent_ontology_term_name,
                          term as display_name,
                          cast(null as varchar2(1)) as description,
@@ -363,7 +363,7 @@ select distinct ontology_term_source_id as ontology_term_name, parent_ontology_t
                   from apidbTuning.TaxonAbundance
                   where dataset_name = $$metadata_datasets$$
                 union
-                  select term_id as ontology_term_name,
+                  select category || ':' || term as ontology_term_name,
                          category as parent_ontology_term_name,
                          term as display_name,
                          cast(null as varchar2(1)) as description,
@@ -388,7 +388,7 @@ select distinct ontology_term_source_id as ontology_term_name, parent_ontology_t
           <sql>
             <![CDATA[
                      select protocol_app_node_id as internal,
-                     term_id as ontology_term_name,
+                     category || ':' || term as ontology_term_name,
                      cast(value as number) as number_value,
                      cast(null as date) as date_value,
                      cast(null as varchar2(1)) as string_value
@@ -409,7 +409,7 @@ select distinct ontology_term_source_id as ontology_term_name, parent_ontology_t
           <sql>
             <![CDATA[
                      select protocol_app_node_id as internal,
-                     term_id as ontology_term_name,
+                     category || ':' || term as ontology_term_name,
                      cast(value as number) as number_value,
                      cast(null as date) as date_value,
                      cast(null as varchar2(1)) as string_value
@@ -431,7 +431,7 @@ select distinct ontology_term_source_id as ontology_term_name, parent_ontology_t
           <sql>
             <![CDATA[
                      select protocol_app_node_id as internal,
-                     term_id as ontology_term_name,
+                     category || ':' || term as ontology_term_name,
                      cast(value as number) as number_value,
                      cast(null as date) as date_value,
                      cast(null as varchar2(1)) as string_value
@@ -450,7 +450,7 @@ select distinct ontology_term_source_id as ontology_term_name, parent_ontology_t
           <sql>
             <![CDATA[
                      select protocol_app_node_id as internal,
-                     term_id as ontology_term_name,
+                     category || ':' || term as ontology_term_name,
                      cast(value as number) as number_value,
                      cast(null as date) as date_value,
                      cast(null as varchar2(1)) as string_value
@@ -499,7 +499,7 @@ select distinct ontology_term_source_id as ontology_term_name, parent_ontology_t
                          taxon_level * 2 - 1 as ordering
                   from apidbTuning.TaxonAbundance
                 union
-                  select term_id as ontology_term_name,
+                  select category || ':' || term as ontology_term_name,
                          category as parent_ontology_term_name,
                          term as display_name,
                          cast(null as varchar2(1)) as description,

--- a/Model/lib/wdk/model/records/microbiomeSampleTableQueries.xml
+++ b/Model/lib/wdk/model/records/microbiomeSampleTableQueries.xml
@@ -66,7 +66,6 @@ from
 
     <sqlQuery name="TaxaRelativeAbundance">
       <column name="name"/>
-      <column name="taxon_id"/>
       <column name="ncbi_tax_id"/>
       <column name="kingdom"/>
       <column name="phylum"/>
@@ -79,7 +78,7 @@ from
       <column name="absolute_abundance"/>
         <sql>
           <![CDATA[
-            select name, taxon_id, ncbi_tax_id, kingdom, phylum, class, rank_order, 
+            select name, ncbi_tax_id, kingdom, phylum, class, rank_order, 
                    family, genus, species, relative_abundance, absolute_abundance
             from apidbTuning.TaxonRelativeAbundance
           ]]>


### PR DESCRIPTION
Bump release number

Remove unused column taxon_id (which used to be a PK in sres.Taxon table before, and isn't referenced now)

term + category instead of term_id: just the term isn't fine, because of an ambiguous term, 'Incertae Sedis'.